### PR TITLE
refactor(navigation): Centralize navigation architecture

### DIFF
--- a/TMI/Views/MainTabView.swift
+++ b/TMI/Views/MainTabView.swift
@@ -131,55 +131,50 @@ struct MainTabView: View {
   // MARK: - iOS  Tab View
 
   var enhancedIOSTabView: some View {
-    ZStack(alignment: .bottom) {
-      // Tab Content Area without navigation stacks
-      TabView(selection: $selectedTab) {
-        ForEach(availableTabs, id: \.id) { tab in
-          destinationView(for: tab)
-            .navigationTitle(tabLabel(for: tab))
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-              ToolbarItem(placement: .navigationBarTrailing) {
-                Menu {
+      ZStack(alignment: .bottom) {
+          // Tab Content Area
+          destinationView(for: selectedTab)
+              .safeAreaInset(edge: .bottom) {
+                  // Gives space for our custom tab bar
+                  Spacer().frame(height: 70)
+              }
+
+          // Custom Tab Bar
+          PremiumGlassTabBar(
+              selectedTab: $selectedTab,
+              previousTab: $previousTab,
+              availableTabs: availableTabs
+          )
+          .offset(y: tabBarVisible ? 0 : 100)
+      }
+      .navigationTitle(tabLabel(for: selectedTab))
+      .navigationBarTitleDisplayMode(.large)
+      .toolbar {
+          ToolbarItem(placement: .navigationBarTrailing) {
+              Menu {
                   Button {
-                    showingUserProfile = true
+                      showingUserProfile = true
                   } label: {
-                    Label("Profile", systemImage: "person.crop.circle")
+                      Label("Profile", systemImage: "person.crop.circle")
                   }
                   
                   Divider()
                   
                   Button(role: .destructive) {
-                    showingSignOutConfirmation = true
+                      showingSignOutConfirmation = true
                   } label: {
-                    Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                      Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                   }
-                } label: {
+              } label: {
                   Image(systemName: "person.crop.circle.fill")
-                    .font(.system(size: 22))
-                    .foregroundColor(.white)
-                }
+                      .font(.system(size: 22))
+                      .foregroundColor(.white)
               }
-            }
-            .tag(tab)
-        }
+          }
       }
-      .safeAreaInset(edge: .bottom) {
-        // Gives space for our custom tab bar
-        Spacer().frame(height: 70)
+      .onChange(of: selectedTab) { oldValue, newValue in
+          previousTab = oldValue
       }
-
-      // Custom Tab Bar
-      PremiumGlassTabBar(
-        selectedTab: $selectedTab,
-        previousTab: $previousTab,
-        availableTabs: availableTabs
-      )
-      .offset(y: tabBarVisible ? 0 : 100)
-    }
-    .onChange(of: selectedTab) { oldValue, newValue in
-      previousTab = oldValue
-    }
   }
 
   // MARK: - iPadOS/macOS  View

--- a/TMI/Views/Students/StudentListView.swift
+++ b/TMI/Views/Students/StudentListView.swift
@@ -27,24 +27,22 @@ struct StudentListView: View {
             TMIBackgroundView(variant: .default)
                 .ignoresSafeArea()
             
-            NavigationStack {
-                VStack(spacing: 0) {
-                    // Search and filter bar
-                    searchAndFilterBar
-                        .padding(.top, 10)
-                        .padding(.horizontal)
-                        .opacity(searchBarAppeared ? 1 : 0)
-                        .offset(y: searchBarAppeared ? 0 : -20)
-                    
-                    // Main content
-                    mainContent
-                        .opacity(gridAppeared ? 1 : 0)
-                    
-                    // Quick action bar
-                    quickActionBar
-                        .opacity(actionBarAppeared ? 1 : 0)
-                        .offset(y: actionBarAppeared ? 0 : 100)
-                }
+            VStack(spacing: 0) {
+                // Search and filter bar
+                searchAndFilterBar
+                    .padding(.top, 10)
+                    .padding(.horizontal)
+                    .opacity(searchBarAppeared ? 1 : 0)
+                    .offset(y: searchBarAppeared ? 0 : -20)
+
+                // Main content
+                mainContent
+                    .opacity(gridAppeared ? 1 : 0)
+
+                // Quick action bar
+                quickActionBar
+                    .opacity(actionBarAppeared ? 1 : 0)
+                    .offset(y: actionBarAppeared ? 0 : 100)
             }
             .navigationTitle("Students")
             .foregroundColor(.white)
@@ -67,12 +65,6 @@ struct StudentListView: View {
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
             .presentationCornerRadius(30)
-        }
-        .sheet(item: $stateModel.selectedStudent) { student in
-            StudentDetailView(student: student)
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
-                .presentationCornerRadius(30)
         }
         .alert("Bulk Actions", isPresented: $showingBulkActionsAlert) {
             Button("OK") { }
@@ -280,7 +272,7 @@ struct StudentListView: View {
                     ForEach(stateModel.filteredStudents) { student in
                         StudentCard(student: student)
                             .onTapGesture {
-                                stateModel.selectStudent(student)
+                                NavigationCoordinator.shared.navigate(to: .studentDetail(student))
                             }
                     }
                 }


### PR DESCRIPTION
Refactored the app's navigation to use a single, centralized `NavigationStack` and a `NavigationCoordinator`.

- Replaced the `TabView` in `MainTabView` with a custom view switcher to ensure all tab content exists within the same navigation context.
- Removed a nested `NavigationStack` from `StudentListView`.
- Changed the navigation in `StudentListView` from presenting a `.sheet` to using the `NavigationCoordinator` to push the `StudentDetailView` onto the main stack.

This new architecture resolves issues with disconnected navigation contexts and provides a more robust and scalable navigation system.